### PR TITLE
Added an API for blocking purchase

### DIFF
--- a/source/ApiShop.cs
+++ b/source/ApiShop.cs
@@ -8,6 +8,7 @@ namespace Shop.Api;
 public class ApiShop : IShopApi
 {
     public event Action<CCSPlayerController, int, string, string, int, int, int, int>? ClientBuyItem;
+    public event Func<CCSPlayerController, int, string, string, int, int, int, int, HookResult?>? ClientBuyItemPre;
     public event Action<CCSPlayerController, int, string, int>? ClientSellItem;
     public event Action<CCSPlayerController, int, string, int>? ClientToggleItem;
     public event Action<CCSPlayerController, int, string, int>? ClientUseItem;
@@ -184,6 +185,11 @@ public class ApiShop : IShopApi
     public void OnClientBuyItem(CCSPlayerController player, int ItemID, string CategoryName, string UniqueName, int BuyPrice, int SellPrice, int Duration, int Count)
     {
         ClientBuyItem?.Invoke(player, ItemID, CategoryName, UniqueName, BuyPrice, SellPrice, Duration, Count);
+    }
+
+    public HookResult? OnClientBuyItemPre(CCSPlayerController player, int ItemID, string CategoryName, string UniqueName, int BuyPrice, int SellPrice, int Duration, int Count)
+    {
+        return ClientBuyItemPre?.Invoke(player, ItemID, CategoryName, UniqueName, BuyPrice, SellPrice, Duration, Count);
     }
 
     public void OnClientSellItem(CCSPlayerController player, int ItemID, string UniqueName, int SellPrice)

--- a/source/IShopApi/IShopApi.cs
+++ b/source/IShopApi/IShopApi.cs
@@ -336,6 +336,9 @@ public interface IShopApi
 	
 	// Игрок, Айди предмета, Название категории, Уникальное имя предмета, Цена покупки, Цена продажи, Длительность предмета, Кол-во предмета. Return: Continue = Продолжить без изменений, другое заблокирует покупку
 	event Action<CCSPlayerController, int, string, string, int, int, int, int>? ClientBuyItem;
+
+    // Игрок, Айди предмета, Название категории, Уникальное имя предмета, Цена покупки, Цена продажи, Длительность предмета, Кол-во предмета. Return: Continue = Продолжить без изменений, другое заблокирует покупку
+	event Func<CCSPlayerController, int, string, string, int, int, int, int, HookResult?>? ClientBuyItemPre;
 	
 	// Игрок, Айди предмета, Уникальное имя предмета, Цена продажи. Return: Continue = Продолжить без изменений, другое заблокирует продажу
 	event Action<CCSPlayerController, int, string, int>? ClientSellItem;

--- a/source/Shop.cs
+++ b/source/Shop.cs
@@ -285,7 +285,7 @@ public class Shop : BasePlugin, IPluginConfig<ShopConfig>
     {
         var result = _api!.OnClientBuyItemPre(player, ItemID, Item.Category, UniqueName, Item.BuyPrice, Item.SellPrice, Item.Duration, Item.Count);
 
-        if(result != HookResult.Continue)
+        if(result == HookResult.Handled || result == HookResult.Stop)
         {
             return;
         }

--- a/source/Shop.cs
+++ b/source/Shop.cs
@@ -287,6 +287,7 @@ public class Shop : BasePlugin, IPluginConfig<ShopConfig>
 
         if(result == HookResult.Handled || result == HookResult.Stop)
         {
+            OnChooseItem(player, ItemName, UniqueName);
             return;
         }
 

--- a/source/Shop.cs
+++ b/source/Shop.cs
@@ -19,7 +19,7 @@ public class Shop : BasePlugin, IPluginConfig<ShopConfig>
     public override string ModuleName => "Shop Core";
     public override string ModuleDescription => "Modular shop system";
     public override string ModuleAuthor => "Ganter1234";
-    public override string ModuleVersion => "2.3";
+    public override string ModuleVersion => "2.4";
     public ShopConfig Config { get; set; } = new();
     public PlayerInformation[] playerInfo = new PlayerInformation[65];
     public List<Items> ItemsList = new();
@@ -283,6 +283,13 @@ public class Shop : BasePlugin, IPluginConfig<ShopConfig>
     }
     public void OnChooseBuy(CCSPlayerController player, string ItemName, string UniqueName, int ItemID, Items Item, ItemInfo? playerList)
     {
+        var result = _api!.OnClientBuyItemPre(player, ItemID, Item.Category, UniqueName, Item.BuyPrice, Item.SellPrice, Item.Duration, Item.Count);
+
+        if(result != HookResult.Continue)
+        {
+            return;
+        }
+
         if(Item.BuyPrice > GetClientCredits(player))
         {
             player.PrintToChat(StringExtensions.ReplaceColorTags(Localizer["NotEnoughMoney"]));


### PR DESCRIPTION
As it says in the title.

This is exactly like ``ItemCallback`` except ``ItemballBack`` require player to purchase specific item to trigger ``HookResult``, this new implementation is hooking for any purchase that made by player without setting on specific item.

I saw description on this and tested, however they never get blocked.
```cs
// Игрок, Айди предмета, Название категории, Уникальное имя предмета, Цена покупки, Цена продажи, Длительность предмета, Кол-во предмета. Return: Continue = Продолжить без изменений, другое заблокирует покупку
event Action<CCSPlayerController, int, string, string, int, int, int, int>? ClientBuyItem;
```

 